### PR TITLE
Toposort

### DIFF
--- a/dectate/__init__.py
+++ b/dectate/__init__.py
@@ -6,3 +6,4 @@ from .error import (ConfigError, DirectiveError, TopologicalSortError,
 from .query import Query
 from .tool import (query_tool, auto_query_tool,
                    convert_dotted_name, convert_bool, query_app)
+from .toposort import topological_sort

--- a/dectate/error.py
+++ b/dectate/error.py
@@ -67,5 +67,6 @@ class TopologicalSortError(ValueError):
     This is due to circular dependencies.
     """
 
+
 class QueryError(Exception):
     pass

--- a/dectate/error.py
+++ b/dectate/error.py
@@ -61,9 +61,11 @@ class DirectiveError(ConfigError):
     pass
 
 
-class TopologicalSortError(Exception):
-    pass
+class TopologicalSortError(ValueError):
+    """Raised if dependencies cannot be sorted topologically.
 
+    This is due to circular dependencies.
+    """
 
 class QueryError(Exception):
     pass

--- a/dectate/tests/test_toposort.py
+++ b/dectate/tests/test_toposort.py
@@ -1,0 +1,33 @@
+from dectate import topological_sort, TopologicalSortError
+
+import pytest
+
+
+def test_topological_sort_on_dcg():
+    adjacency = {
+        'A': ['B', 'C'],
+        'B': ['C', 'D'],
+        'C': ['D'],
+        'D': ['C'],
+        'E': ['F'],
+        'F': ['C']}
+    with pytest.raises(TopologicalSortError):
+        topological_sort(adjacency.keys(), adjacency.__getitem__)
+
+
+def test_topological_sort_on_dag():
+    adjacency = {
+        'A': ['B', 'C'],
+        'B': ['C', 'D'],
+        'C': ['D'],
+        'D': [],
+        'E': ['F'],
+        'F': ['C']}
+    nodes = sorted(adjacency.keys())
+    # Topological ordering is not unique, and in this implementation
+    # the resulting order depends on the initial ordering of the
+    # nodes::
+    assert topological_sort(nodes, adjacency.__getitem__) == \
+        ['D', 'C', 'B', 'A', 'F', 'E']
+    assert topological_sort(reversed(nodes), adjacency.__getitem__) == \
+        ['D', 'C', 'F', 'E', 'B', 'A']

--- a/dectate/toposort.py
+++ b/dectate/toposort.py
@@ -1,8 +1,24 @@
-class TopologicalSortError(Exception):
-    pass
+from .error import TopologicalSortError
 
 
 def topological_sort(l, get_depends):
+    """`Topological sort`_
+
+    .. _`Topological sort`: https://en.wikipedia.org/wiki/Topological_sorting
+
+    Given a list of items that depend on each other, sort so that
+    dependencies come before the dependent items. Dependency graph must
+    be a DAG_.
+
+    .. _DAG: https://en.wikipedia.org/wiki/Directed_acyclic_graph
+
+    :param l: a list of items to sort
+    :param get_depends: a function that given an item
+      gives other items that this item depends on. This item
+      will be sorted after the items it depends on.
+    :return: the list sorted topologically.
+
+    """
     result = []
     marked = set()
     temporary_marked = set()


### PR DESCRIPTION
This addresses #21, [morepath#403](https://github.com/morepath/morepath/issues/403) and touches upon #20.
1. Made topological_sort exportable from `__init__`.
2. Removed the duplicated definition of TopologicalSortError.
3. Copied the docstrings from morepath.
4. Added specific tests for topological_sort:
   - One of these tests, if you merge check-in by check-in, will show the problem with the duplicate definition of TopologicalSortError. 
   - The other test shows how the initial ordering of the nodes affects which of the possible topological orderings is returned by the topological_sort.
