### PR TITLE
repr of directives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,10 @@ script:
     - tox -e $TOXENV
 after_success:
     - if [ "$TOXENV" = 'coverage' ]; then coveralls; fi
+
+# Necessary until travis includes python 3.5 by default.
+matrix:
+  include:
+    - python: 3.5
+      env:
+      - TOXENV=py35

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,8 @@ CHANGES
 
 - Fix ``repr`` of directives so that you can at least see their name.
 
+- Added support for Python 3.5.
+
 0.10.2 (2016-04-26)
 ===================
 

--- a/dectate/app.py
+++ b/dectate/app.py
@@ -169,6 +169,10 @@ class DirectiveDirective(object):
         method.action_factory = action_factory  # to help sphinxext
         setattr(self.cls, self.name, classmethod(method))
         method.__name__ = self.name
+        # As of Python 3.5, the repr of bound methods uses __qualname__ instead
+        # of __name__.  See http://bugs.python.org/issue21389#msg217566
+        if hasattr(method, '__qualname__'):
+            method.__qualname__ = type(self.cls).__name__ + '.' + self.name
         method.__doc__ = action_factory.__doc__
         method.__module__ = action_factory.__module__
         self.cls.dectate.register_action_class(action_factory)

--- a/dectate/tests/test_directive.py
+++ b/dectate/tests/test_directive.py
@@ -1,5 +1,4 @@
 from dectate.app import App
-from dectate.compat import PY3, PYPY
 from dectate.config import commit, Action, Composite
 from dectate.error import ConflictError, ConfigError
 
@@ -1661,11 +1660,15 @@ def test_registry_factory_argument_and_config_inconsistent():
         commit(MyApp)
 
 
-def test_directive_repr():
-    class MyApp(App):
-        pass
+# Due to PEP 3155, having this class defined at the module top-level ensures
+# that its repr is the same in both Python 2 and 3.
+class MyAppForRepr(App):
+    pass
 
-    @MyApp.directive('foo')
+
+def test_directive_repr():
+
+    @MyAppForRepr.directive('foo')
     class MyDirective(Action):
         """Doc"""
         config = {
@@ -1681,15 +1684,6 @@ def test_directive_repr():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    if not PY3 or PYPY:
-        # XXX even PYPY 3 produces this on my machine, but it might be
-        # different in newer versions of PYPY 3
-        assert repr(MyApp.foo) == (
-            "<bound method AppMeta.foo of "
-            "<class 'dectate.tests.test_directive.MyApp'>>")
-    else:
-        assert repr(MyApp.foo) == (
-            "<bound method AppMeta.foo of "
-            "<class 'dectate.tests.test_directive.test_directive_repr."
-            "<locals>.MyApp'>>"
-        )
+    assert repr(MyAppForRepr.foo) == (
+        "<bound method AppMeta.foo of "
+        "<class 'dectate.tests.test_directive.MyAppForRepr'>>")

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Development Status :: 5 - Production/Stable'
     ],
     keywords="configuration",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,pypy,pypy3,coverage
+envlist = py27,py34,py35,pypy,pypy3,coverage
 
 [testenv]
 deps = -e{toxinidir}[test]


### PR DESCRIPTION
This pull requests contains work related to #29:
- It uses the same test assertion for all pythons.
- It adds support to Python 3.5, showing that test_directive_repr fails on Python 3.5
