### PR TITLE
No more directive directive

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,12 @@ CHANGES
   So, you define the directives directly on the app class that needs
   them.
 
+  Uses of ``private_action_class`` should be replaced by an underscored
+  directive definition::
+
+     class MyApp(dectate.App):
+        _my_private_thing = directive(PrivateAction)
+
 - Use the same Git ignore file used in other Morepath projects.
 
 - If you set the ``app_class_arg`` class attribute to ``True`` on an

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,32 @@ CHANGES
 0.12 (unreleased)
 =================
 
+- **Breaking changes**: previously you defined new directives using the
+  ``App.directive`` directive. This would lead to import confusion: you
+  *have* to import the modules that define directives before you can actually
+  use them, even though you've already imported your app class.
+
+  In this version of Dectate we've changed the way you define directives.
+  Instead of::
+
+     class MyApp(dectate.App):
+         pass
+
+     @MyApp.directive('foo')
+     class FooAction(dectate.Action):
+        ...
+
+  You now write this::
+
+     class FooAction(directive.Action)
+         ...
+
+     class MyApp(dectate.App):
+         foo = directive(FooAction)
+
+  So, you define the directives directly on the app class that needs
+  them.
+
 - Use the same Git ignore file used in other Morepath projects.
 
 - If you set the ``app_class_arg`` class attribute to ``True`` on an

--- a/dectate/__init__.py
+++ b/dectate/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from .app import App
+from .app import App, directive
 from .config import commit, Action, Composite, CodeInfo, NOT_FOUND
 from .error import (ConfigError, DirectiveError, TopologicalSortError,
                     DirectiveReportError, ConflictError, QueryError)

--- a/dectate/app.py
+++ b/dectate/app.py
@@ -62,56 +62,6 @@ class App(with_metaclass(AppMeta)):
     a very dumb object that has no methods and is just a container for
     attributes that contain the real configuration.
     """
-
-    @classmethod
-    def directive(cls, name):
-        """Decorator to register a new directive with this application class.
-
-        You use this as a class decorator for a
-        :class:`dectate.Action` or a :class:`dectate.Composite`
-        subclass::
-
-           @MyApp.directive('my_directive')
-           class FooAction(dectate.Action):
-               ...
-
-        This needs to be executed *before* the directive is used and
-        thus might introduce import dependency issues unlike normal
-        Dectate configuration, so beware! An easy way to make sure
-        that all directives are installed before you use them is to
-        make sure you define them in the same module as where you
-        define the :class:`App` subclass that has them.
-
-        :param name: the name of the directive to register.
-        :return: a directive that when called installs the directive
-          method on the class.
-        """
-        return DirectiveDirective(cls, name)
-
-    @classmethod
-    def private_action_class(cls, action_class):
-        """Register a private action class.
-
-        In some cases action classes can be an implementation detail,
-        for instance in the implementation of a Composite action.
-
-        In this case you don't want the action class to be known
-        but not have a directive.
-
-        This function may be used as a decorator like this::
-
-          @App.private_action_class
-          class MyActionClass(dectate.Action):
-              ...
-
-        :param action_class: the :class:`dectate.Action` subclass to register.
-        :return: the :class`dectate.Action` class that was registered.
-        """
-        # XXX this isn't right and should go away
-        cls.dectate.register_action_class(
-            action_class.__class__.__name__, action_class)
-        return action_class
-
     @classmethod
     def get_directive_methods(cls):
         for name in dir(cls):
@@ -191,39 +141,3 @@ def directive(action_factory):
     method.__doc__ = action_factory.__doc__
     method.__module__ = action_factory.__module__
     return classmethod(method)
-
-
-class DirectiveDirective(object):
-    """Implementation of the ``directive`` directive.
-
-    :param cls: the class that this directive is registered on.
-    :param name: the name of the directive.
-    """
-    def __init__(self, cls, name):
-        self.cls = cls
-        self.name = name
-
-    def __call__(self, action_factory):
-        """Register the directive with app class.
-
-        Creates a class method on the app class for the directive.
-
-        :param action_factory: the :class:`dectate.Action` or
-          :class:`dectate.Composite` subclass to register.
-        :return: the action or composite subclass that was registered.
-        """
-        def method(cls, *args, **kw):
-            frame = sys._getframe(1)
-            code_info = create_code_info(frame)
-            return Directive(action_factory, code_info, cls, args, kw)
-        method.action_factory = action_factory  # to help sphinxext
-        setattr(self.cls, self.name, classmethod(method))
-        method.__name__ = self.name
-        # As of Python 3.5, the repr of bound methods uses __qualname__ instead
-        # of __name__.  See http://bugs.python.org/issue21389#msg217566
-        if hasattr(method, '__qualname__'):
-            method.__qualname__ = type(self.cls).__name__ + '.' + self.name
-        method.__doc__ = action_factory.__doc__
-        method.__module__ = action_factory.__module__
-        self.cls.dectate.register_action_class(self.name, action_factory)
-        return action_factory

--- a/dectate/app.py
+++ b/dectate/app.py
@@ -122,11 +122,6 @@ class App(with_metaclass(AppMeta)):
                 yield name, attr
 
     @classmethod
-    def get_action_classes(cls):
-        for name, method in cls.get_directive_methods():
-            yield method.__func__.action_factory
-
-    @classmethod
     def commit(cls):
         """Commit this class and any depending on it.
 
@@ -162,6 +157,29 @@ class App(with_metaclass(AppMeta)):
 
 
 def directive(action_factory):
+    """Create a classmethod to hook action to application class.
+
+    You pass in a :class:`dectate.Action` or a
+    :class:`dectate.Composite` subclass and can attach the result as a
+    class method to an :class:`dectate.App` subclass::
+
+      class FooAction(dectate.Action):
+          ...
+
+      class MyApp(dectate.App):
+          my_directive = dectate.directive(MyAction)
+
+    Alternatively you can also define the direction inline using
+    this as a decorator::
+
+      class MyApp(dectate.App):
+          @directive
+          class my_directive(dectate.Action):
+              ...
+
+    :param action_factory: an action class to use as the directive.
+    :return: a class method that represents the directive.
+    """
     def method(cls, *args, **kw):
         frame = sys._getframe(1)
         code_info = create_code_info(frame)

--- a/dectate/app.py
+++ b/dectate/app.py
@@ -112,16 +112,19 @@ class App(with_metaclass(AppMeta)):
         return action_class
 
     @classmethod
-    def get_action_classes(cls):
+    def get_directive_methods(cls):
         for name in dir(cls):
             attr = getattr(cls, name)
             im_func = getattr(attr, '__func__', None)
             if im_func is None:
                 continue
-            action_factory = getattr(im_func, 'action_factory', None)
-            if action_factory is None:
-                continue
-            yield action_factory
+            if hasattr(im_func, 'action_factory'):
+                yield name, attr
+
+    @classmethod
+    def get_action_classes(cls):
+        for name, method in cls.get_directive_methods():
+            yield method.__func__.action_factory
 
     @classmethod
     def commit(cls):
@@ -158,7 +161,7 @@ class App(with_metaclass(AppMeta)):
         pass
 
 
-def directive(action_factory, private=False):
+def directive(action_factory):
     def method(cls, *args, **kw):
         frame = sys._getframe(1)
         code_info = create_code_info(frame)

--- a/dectate/app.py
+++ b/dectate/app.py
@@ -62,6 +62,7 @@ class App(with_metaclass(AppMeta)):
     a very dumb object that has no methods and is just a container for
     attributes that contain the real configuration.
     """
+
     @classmethod
     def get_directive_methods(cls):
         for name in dir(cls):
@@ -131,7 +132,6 @@ def directive(action_factory):
     :param action_factory: an action class to use as the directive.
     :return: a class method that represents the directive.
     """
-
     def method(cls, *args, **kw):
         frame = sys._getframe(1)
         code_info = create_code_info(frame)

--- a/dectate/app.py
+++ b/dectate/app.py
@@ -166,7 +166,7 @@ def directive(action_factory):
         frame = sys._getframe(1)
         code_info = create_code_info(frame)
         # XXX disabled logging behavior
-        #logger = logging.getLogger('%s.%s' %
+        # logger = logging.getLogger('%s.%s' %
         # (cls.logger_name, self.name))
         return Directive(cls, action_factory, args, kw,
                          code_info, None, None)

--- a/dectate/config.py
+++ b/dectate/config.py
@@ -815,6 +815,8 @@ def commit(*apps):
         if isinstance(c, Configurable):
             configurables.append(c)
         else:
+            for action_class in c.get_action_classes():
+                c.dectate.register_action_class(action_class)
             configurables.append(c.dectate)
 
     for configurable in sort_configurables(configurables):

--- a/dectate/config.py
+++ b/dectate/config.py
@@ -84,6 +84,18 @@ class Configurable(object):
 
         Takes inheritance of apps into account.
         """
+        # register all directives found on this app class
+        app_class = self.app_class
+        for name, method in app_class.get_directive_methods():
+            func = method.__func__
+            func.__name__ = name
+            # As of Python 3.5, the repr of bound methods uses
+            # __qualname__ instead of __name__.
+            # See http://bugs.python.org/issue21389#msg217566
+            if hasattr(func, '__qualname__'):
+                func.__qualname__ = type(c).__name__ + '.' + name
+            self.register_action_class(name, func.action_factory)
+
         # add any action classes defined by base classes
         s = self._action_classes
         for configurable in self.extends:
@@ -815,16 +827,6 @@ def commit(*apps):
             configurables.append(c.dectate)
 
     for configurable in sort_configurables(configurables):
-        app_class = configurable.app_class
-        for name, method in app_class.get_directive_methods():
-            func = method.__func__
-            func.__name__ = name
-            # As of Python 3.5, the repr of bound methods uses
-            # __qualname__ instead of __name__.
-            # See http://bugs.python.org/issue21389#msg217566
-            if hasattr(func, '__qualname__'):
-                func.__qualname__ = type(c).__name__ + '.' + name
-            configurable.register_action_class(name, func.action_factory)
         configurable.execute()
 
 

--- a/dectate/config.py
+++ b/dectate/config.py
@@ -82,7 +82,7 @@ class Configurable(object):
             # __qualname__ instead of __name__.
             # See http://bugs.python.org/issue21389#msg217566
             if hasattr(func, '__qualname__'):
-                func.__qualname__ = type(c).__name__ + '.' + name
+                func.__qualname__ = type(app_class).__name__ + '.' + name
             result[func.action_factory] = name
 
         # add any action classes defined by base classes

--- a/dectate/config.py
+++ b/dectate/config.py
@@ -815,6 +815,8 @@ def commit(*apps):
         if isinstance(c, Configurable):
             configurables.append(c)
         else:
+            for name, method in c.get_directive_methods():
+                method.__func__.__name__ = name
             for action_class in c.get_action_classes():
                 c.dectate.register_action_class(action_class)
             configurables.append(c.dectate)

--- a/dectate/config.py
+++ b/dectate/config.py
@@ -816,7 +816,13 @@ def commit(*apps):
             configurables.append(c)
         else:
             for name, method in c.get_directive_methods():
-                method.__func__.__name__ = name
+                func = method.__func__
+                func.__name__ = name
+                # As of Python 3.5, the repr of bound methods uses
+                # __qualname__ instead of __name__.
+                # See http://bugs.python.org/issue21389#msg217566
+                if hasattr(func, '__qualname__'):
+                    func.__qualname__ = type(c).__name__ + '.' + name
             for action_class in c.get_action_classes():
                 c.dectate.register_action_class(action_class)
             configurables.append(c.dectate)

--- a/dectate/config.py
+++ b/dectate/config.py
@@ -1,4 +1,5 @@
 import abc
+import logging
 import sys
 import inspect
 from .error import (
@@ -47,21 +48,22 @@ class Configurable(object):
         self.extends = extends
         self.config = config
         # all action classes known
-        self._action_classes = set()
+        self._action_classes = {}
         # directives used with configurable
         self._directives = []
         # have we ever been committed
         self.committed = False
 
-    def register_action_class(self, action_class):
-        """Register an action class with this configurable.
+    def register_action_class(self, name, action_class):
+        """Register an action class with this configurable under a name.
 
-        Called during import time when the :meth:`App.directive` directive
-        is executed.
+        Called during commit time for all directive methods found on the
+        app class.
 
         :param action_class: the :class:`dectate.Action` subclass to register.
+        :param name: the name under which it is attached to the app class.
         """
-        self._action_classes.add(action_class)
+        self._action_classes[action_class] = name
 
     def register_directive(self, directive, obj):
         """Register a directive with this configurable.
@@ -85,13 +87,13 @@ class Configurable(object):
         # add any action classes defined by base classes
         s = self._action_classes
         for configurable in self.extends:
-            for action_class in configurable._action_classes:
+            for action_class, name in configurable._action_classes.items():
                 if action_class not in s:
-                    s.add(action_class)
+                    s[action_class] = name
 
         # we want to have use group_class for each true Action class
         action_classes = set()
-        for action_class in s:
+        for action_class in s.keys():
             if not issubclass(action_class, Action):
                 continue
             group_class = action_class.group_class
@@ -678,28 +680,23 @@ class Directive(object):
     When used as a decorator this tracks where in the source code
     the directive was used for the purposes of error reporting.
     """
-    def __init__(self, app_class, action_factory, args, kw,
-                 code_info, directive_name, logger):
+    def __init__(self, action_factory, code_info, app_class, args, kw):
         """
-        :param app_class: the :class:`dectate.App` subclass that this
-          directive is used on.
         :param action_factory: function that constructs an action instance.
-        :args: the positional arguments passed into the directive.
-        :kw: the keyword arguments passed into the directive.
         :code_info: a :class:`CodeInfo` instance describing where this
           directive was invoked.
-        :directive_name: the name of this directive.
-        :logger: the logger object to use.
+        :param app_class: the :class:`dectate.App` subclass that this
+          directive is used on.
+        :args: the positional arguments passed into the directive.
+        :kw: the keyword arguments passed into the directive.
         """
+        self.action_factory = action_factory
+        self.code_info = code_info
         self.app_class = app_class
         self.configurable = app_class.dectate
-        self.action_factory = action_factory
         self.args = args
         self.kw = kw
-        self.code_info = code_info
-        self.directive_name = directive_name
         self.argument_info = (args, kw)
-        self.logger = logger
 
     def action(self):
         """Get the :class:`Action` instance represented by this directive.
@@ -739,8 +736,10 @@ class Directive(object):
         :obj: the function or class object to that this directive is used
           on.
         """
-        if self.logger is None:
-            return
+        directive_name = configurable._action_classes[self.action_factory]
+        logger = logging.getLogger('%s.%s' % (
+            configurable.app_class.logger_name,
+            directive_name))
 
         target_dotted_name = dotted_name(configurable.app_class)
         is_same = self.app_class is configurable.app_class
@@ -761,13 +760,13 @@ class Directive(object):
                  sorted(kw.items())])
 
         message = '@%s.%s(%s) on %s' % (
-            target_dotted_name, self.directive_name, arguments,
+            target_dotted_name, directive_name, arguments,
             func_dotted_name)
 
         if not is_same:
             message += ' (from %s)' % dotted_name(self.app_class)
 
-        self.logger.debug(message)
+        logger.debug(message)
 
 
 class DirectiveAbbreviation(object):
@@ -787,13 +786,11 @@ class DirectiveAbbreviation(object):
         combined_kw = directive.kw.copy()
         combined_kw.update(kw)
         return Directive(
-            app_class=directive.app_class,
             action_factory=directive.action_factory,
-            args=combined_args,
-            kw=combined_kw,
             code_info=code_info,
-            directive_name=directive.directive_name,
-            logger=directive.logger)
+            app_class=directive.app_class,
+            args=combined_args,
+            kw=combined_kw)
 
 
 def commit(*apps):
@@ -827,7 +824,7 @@ def commit(*apps):
             # See http://bugs.python.org/issue21389#msg217566
             if hasattr(func, '__qualname__'):
                 func.__qualname__ = type(c).__name__ + '.' + name
-            configurable.register_action_class(func.action_factory)
+            configurable.register_action_class(name, func.action_factory)
         configurable.execute()
 
 

--- a/dectate/config.py
+++ b/dectate/config.py
@@ -815,19 +815,19 @@ def commit(*apps):
         if isinstance(c, Configurable):
             configurables.append(c)
         else:
-            for name, method in c.get_directive_methods():
-                func = method.__func__
-                func.__name__ = name
-                # As of Python 3.5, the repr of bound methods uses
-                # __qualname__ instead of __name__.
-                # See http://bugs.python.org/issue21389#msg217566
-                if hasattr(func, '__qualname__'):
-                    func.__qualname__ = type(c).__name__ + '.' + name
-            for action_class in c.get_action_classes():
-                c.dectate.register_action_class(action_class)
             configurables.append(c.dectate)
 
     for configurable in sort_configurables(configurables):
+        app_class = configurable.app_class
+        for name, method in app_class.get_directive_methods():
+            func = method.__func__
+            func.__name__ = name
+            # As of Python 3.5, the repr of bound methods uses
+            # __qualname__ instead of __name__.
+            # See http://bugs.python.org/issue21389#msg217566
+            if hasattr(func, '__qualname__'):
+                func.__qualname__ = type(c).__name__ + '.' + name
+            configurable.register_action_class(func.action_factory)
         configurable.execute()
 
 

--- a/dectate/tests/fixtures/anapp.py
+++ b/dectate/tests/fixtures/anapp.py
@@ -1,19 +1,6 @@
 import dectate
 
 
-class AnApp(dectate.App):
-    known = "definitely not a directive"
-
-
-def other():
-    pass
-
-
-class OtherClass(object):
-    pass
-
-
-@AnApp.directive('foo')
 class FooAction(dectate.Action):
     def __init__(self, name):
         self.name = name
@@ -23,3 +10,17 @@ class FooAction(dectate.Action):
 
     def perform(self, obj):
         pass
+
+
+class AnApp(dectate.App):
+    known = "definitely not a directive"
+
+    foo = dectate.directive(FooAction)
+
+
+def other():
+    pass
+
+
+class OtherClass(object):
+    pass

--- a/dectate/tests/test_directive.py
+++ b/dectate/tests/test_directive.py
@@ -6,34 +6,6 @@ import pytest
 
 
 def test_simple():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
-    class MyDirective(Action):
-        config = {
-            'my': list
-        }
-
-        def __init__(self, message):
-            self.message = message
-
-        def identifier(self, my):
-            return self.message
-
-        def perform(self, obj, my):
-            my.append((self.message, obj))
-
-    @MyApp.foo('hello')
-    def f():
-        pass
-
-    commit(MyApp)
-
-    assert MyApp.config.my == [('hello', f)]
-
-
-def test_simple_direct():
     class MyDirective(Action):
         config = {
             'my': list
@@ -61,10 +33,6 @@ def test_simple_direct():
 
 
 def test_commit_method():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -78,6 +46,9 @@ def test_commit_method():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
 
     @MyApp.foo('hello')
     def f():
@@ -90,10 +61,6 @@ def test_commit_method():
 
 
 def test_conflict_same_directive():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -107,6 +74,9 @@ def test_conflict_same_directive():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
 
     @MyApp.foo('hello')
     def f():
@@ -124,13 +94,6 @@ def test_app_inherit():
     class Registry(object):
         pass
 
-    class MyApp(App):
-        pass
-
-    class SubApp(MyApp):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': Registry
@@ -145,6 +108,12 @@ def test_app_inherit():
         def perform(self, obj, my):
             my.message = self.message
             my.obj = obj
+
+    class MyApp(App):
+        foo = directive(MyDirective)
+
+    class SubApp(MyApp):
+        pass
 
     @MyApp.foo('hello')
     def f():
@@ -162,13 +131,6 @@ def test_app_override():
     class Registry(object):
         pass
 
-    class MyApp(App):
-        pass
-
-    class SubApp(MyApp):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': Registry
@@ -183,6 +145,12 @@ def test_app_override():
         def perform(self, obj, my):
             my.message = self.message
             my.obj = obj
+
+    class MyApp(App):
+        foo = directive(MyDirective)
+
+    class SubApp(MyApp):
+        pass
 
     @MyApp.foo('hello')
     def f():
@@ -201,10 +169,6 @@ def test_app_override():
 
 
 def test_different_group_no_conflict():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'foo': list
@@ -219,7 +183,6 @@ def test_different_group_no_conflict():
         def perform(self, obj, foo):
             foo.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         config = {
             'bar': list
@@ -233,6 +196,10 @@ def test_different_group_no_conflict():
 
         def perform(self, obj, bar):
             bar.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
 
     @MyApp.foo('hello')
     def f():
@@ -249,10 +216,6 @@ def test_different_group_no_conflict():
 
 
 def test_same_group_conflict():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'foo': list
@@ -267,7 +230,6 @@ def test_same_group_conflict():
         def perform(self, obj, foo):
             foo.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         # should now conflict
         group_class = FooDirective
@@ -280,6 +242,10 @@ def test_same_group_conflict():
 
         def perform(self, obj, foo):
             foo.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
 
     @MyApp.foo('hello')
     def f():
@@ -294,10 +260,6 @@ def test_same_group_conflict():
 
 
 def test_discriminator_conflict():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': list
@@ -315,6 +277,9 @@ def test_discriminator_conflict():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     @MyApp.foo('f', ['a'])
     def f():
@@ -329,10 +294,6 @@ def test_discriminator_conflict():
 
 
 def test_discriminator_same_group_conflict():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': list
@@ -351,9 +312,12 @@ def test_discriminator_same_group_conflict():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(FooDirective):
         group_class = FooDirective
+
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
 
     @MyApp.foo('f', ['a'])
     def f():
@@ -368,10 +332,6 @@ def test_discriminator_same_group_conflict():
 
 
 def test_discriminator_no_conflict():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': list
@@ -389,6 +349,9 @@ def test_discriminator_no_conflict():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     @MyApp.foo('f', ['a'])
     def f():
@@ -404,10 +367,6 @@ def test_discriminator_no_conflict():
 
 
 def test_discriminator_different_group_no_conflict():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': list
@@ -426,10 +385,13 @@ def test_discriminator_different_group_no_conflict():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(FooDirective):
         # will have its own group key so in a different group
         depends = [FooDirective]
+
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
 
     @MyApp.foo('f', ['a'])
     def f():
@@ -445,10 +407,6 @@ def test_discriminator_different_group_no_conflict():
 
 
 def test_depends():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': list
@@ -463,7 +421,6 @@ def test_depends():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         depends = [FooDirective]
 
@@ -479,6 +436,10 @@ def test_depends():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
 
     @MyApp.bar('a')
     def g():
@@ -495,10 +456,6 @@ def test_depends():
 
 
 def test_composite():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('sub')
     class SubDirective(Action):
         config = {
             'my': list
@@ -513,13 +470,16 @@ def test_composite():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.directive('composite')
     class CompositeDirective(Composite):
         def __init__(self, messages):
             self.messages = messages
 
         def actions(self, obj):
             return [(SubDirective(message), obj) for message in self.messages]
+
+    class MyApp(App):
+        _sub = directive(SubDirective)
+        composite = directive(CompositeDirective)
 
     @MyApp.composite(['a', 'b', 'c'])
     def f():
@@ -531,10 +491,6 @@ def test_composite():
 
 
 def test_composite_change_object():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('sub')
     class SubDirective(Action):
         config = {
             'my': list
@@ -552,7 +508,6 @@ def test_composite_change_object():
     def other():
         pass
 
-    @MyApp.directive('composite')
     class CompositeDirective(Composite):
         def __init__(self, messages):
             self.messages = messages
@@ -560,6 +515,10 @@ def test_composite_change_object():
         def actions(self, obj):
             return [(SubDirective(message),
                      other) for message in self.messages]
+
+    class MyApp(App):
+        _sub = directive(SubDirective)
+        composite = directive(CompositeDirective)
 
     @MyApp.composite(['a', 'b', 'c'])
     def f():
@@ -571,10 +530,6 @@ def test_composite_change_object():
 
 
 def test_composite_private_sub():
-    class MyApp(App):
-        pass
-
-    @MyApp.private_action_class
     class SubDirective(Action):
         config = {
             'my': list
@@ -589,13 +544,17 @@ def test_composite_private_sub():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.directive('composite')
     class CompositeDirective(Composite):
         def __init__(self, messages):
             self.messages = messages
 
         def actions(self, obj):
             return [(SubDirective(message), obj) for message in self.messages]
+
+    class MyApp(App):
+        # mark sub as private by using the underscore
+        _sub = directive(SubDirective)
+        composite = directive(CompositeDirective)
 
     @MyApp.composite(['a', 'b', 'c'])
     def f():
@@ -607,10 +566,6 @@ def test_composite_private_sub():
 
 
 def test_composite_private_composite():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('sub')
     class SubDirective(Action):
         config = {
             'my': list
@@ -625,13 +580,16 @@ def test_composite_private_composite():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.private_action_class
     class CompositeDirective(Composite):
         def __init__(self, messages):
             self.messages = messages
 
         def actions(self, obj):
             return [(SubDirective(message), obj) for message in self.messages]
+
+    class MyApp(App):
+        sub = directive(SubDirective)
+        _composite = directive(CompositeDirective)
 
     @MyApp.sub('a')
     def f():
@@ -643,10 +601,6 @@ def test_composite_private_composite():
 
 
 def test_nested_composite():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('sub')
     class SubDirective(Action):
         config = {
             'my': list
@@ -661,7 +615,6 @@ def test_nested_composite():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.directive('subcomposite')
     class SubCompositeDirective(Composite):
         def __init__(self, message):
             self.message = message
@@ -670,7 +623,6 @@ def test_nested_composite():
             yield SubDirective(self.message + '_0'), obj
             yield SubDirective(self.message + '_1'), obj
 
-    @MyApp.directive('composite')
     class CompositeDirective(Composite):
         def __init__(self, messages):
             self.messages = messages
@@ -678,6 +630,11 @@ def test_nested_composite():
         def actions(self, obj):
             return [(SubCompositeDirective(message), obj)
                     for message in self.messages]
+
+    class MyApp(App):
+        sub = directive(SubDirective)
+        subcomposite = directive(SubCompositeDirective)
+        composite = directive(CompositeDirective)
 
     @MyApp.composite(['a', 'b', 'c'])
     def f():
@@ -693,10 +650,6 @@ def test_nested_composite():
 
 
 def test_with_statement_kw():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': list
@@ -714,6 +667,9 @@ def test_with_statement_kw():
 
     class Dummy(object):
         pass
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     with MyApp.foo(model=Dummy) as foo:
 
@@ -734,10 +690,6 @@ def test_with_statement_kw():
 
 
 def test_with_statement_args():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': list
@@ -752,6 +704,9 @@ def test_with_statement_args():
 
         def perform(self, obj, my):
             my.append((self.model, self.name, obj))
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     class Dummy(object):
         pass
@@ -784,10 +739,6 @@ def test_before():
             assert self.before
             self.l.append((name, obj))
 
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': Registry
@@ -805,6 +756,9 @@ def test_before():
         @staticmethod
         def before(my):
             my.before = True
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     @MyApp.foo(name='hello')
     def f():
@@ -828,10 +782,6 @@ def test_before_without_use():
             assert self.before
             self.l.append((name, obj))
 
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': Registry
@@ -849,6 +799,9 @@ def test_before_without_use():
         @staticmethod
         def before(my):
             my.before = True
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     commit(MyApp)
 
@@ -866,10 +819,6 @@ def test_before_group():
             assert self.before
             self.l.append((name, obj))
 
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': Registry
@@ -888,7 +837,6 @@ def test_before_group():
         def before(my):
             my.before = True
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         group_class = FooDirective
 
@@ -900,6 +848,10 @@ def test_before_group():
 
         def perform(self, obj, my):
             pass
+
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
 
     @MyApp.bar(name='bye')
     def f():
@@ -918,10 +870,6 @@ def test_before_group():
 
 
 def test_config_group():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': list
@@ -936,7 +884,6 @@ def test_config_group():
         def perform(self, obj, my):
             my.append((self.name, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         group_class = FooDirective
 
@@ -948,6 +895,10 @@ def test_config_group():
 
         def perform(self, obj, my):
             my.append((self.name, obj))
+
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
 
     @MyApp.bar(name='bye')
     def f():
@@ -974,10 +925,6 @@ def test_before_group_without_use():
             assert self.before
             self.l.append((name, obj))
 
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': Registry
@@ -996,7 +943,6 @@ def test_before_group_without_use():
         def before(my):
             my.before = True
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         group_class = FooDirective
 
@@ -1008,6 +954,10 @@ def test_before_group_without_use():
 
         def perform(self, obj):
             pass
+
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
 
     commit(MyApp)
 
@@ -1025,10 +975,6 @@ def test_after():
             assert not self.after
             self.l.append((name, obj))
 
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': Registry
@@ -1046,6 +992,9 @@ def test_after():
         @staticmethod
         def after(my):
             my.after = True
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     @MyApp.foo(name='hello')
     def f():
@@ -1069,10 +1018,6 @@ def test_after_without_use():
             assert not self.after
             self.l.append((name, obj))
 
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': Registry
@@ -1091,6 +1036,9 @@ def test_after_without_use():
         def after(my):
             my.after = True
 
+    class MyApp(App):
+        foo = directive(FooDirective)
+
     commit(MyApp)
 
     assert MyApp.config.my.after
@@ -1098,10 +1046,6 @@ def test_after_without_use():
 
 
 def test_action_loop_should_conflict():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -1116,6 +1060,9 @@ def test_action_loop_should_conflict():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
+    class MyApp(App):
+        foo = directive(MyDirective)
+
     for i in range(2):
         @MyApp.foo('hello')
         def f():
@@ -1126,12 +1073,8 @@ def test_action_loop_should_conflict():
 
 
 def test_action_init_only_during_commit():
-    class MyApp(App):
-        pass
-
     init_called = []
 
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -1147,6 +1090,9 @@ def test_action_init_only_during_commit():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
+    class MyApp(App):
+        foo = directive(MyDirective)
+
     @MyApp.foo('hello')
     def f():
         pass
@@ -1159,10 +1105,6 @@ def test_action_init_only_during_commit():
 
 
 def test_registry_should_exist_even_without_directive_use():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -1176,6 +1118,9 @@ def test_registry_should_exist_even_without_directive_use():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
 
     commit(MyApp)
 
@@ -1183,13 +1128,6 @@ def test_registry_should_exist_even_without_directive_use():
 
 
 def test_registry_should_exist_even_without_directive_use_subclass():
-    class MyApp(App):
-        pass
-
-    class SubApp(MyApp):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -1203,6 +1141,12 @@ def test_registry_should_exist_even_without_directive_use_subclass():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
+
+    class SubApp(MyApp):
+        pass
 
     commit(MyApp, SubApp)
 
@@ -1211,10 +1155,6 @@ def test_registry_should_exist_even_without_directive_use_subclass():
 
 
 def test_rerun_commit():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -1228,6 +1168,9 @@ def test_rerun_commit():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
 
     @MyApp.foo('hello')
     def f():
@@ -1242,10 +1185,6 @@ def test_rerun_commit():
 
 
 def test_rerun_commit_add_directive():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -1259,6 +1198,9 @@ def test_rerun_commit_add_directive():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
 
     @MyApp.foo('hello')
     def f():
@@ -1277,13 +1219,6 @@ def test_rerun_commit_add_directive():
 
 
 def test_order_subclass():
-    class MyApp(App):
-        pass
-
-    class SubApp(MyApp):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -1297,6 +1232,12 @@ def test_order_subclass():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
+
+    class SubApp(MyApp):
+        pass
 
     @SubApp.foo('c')
     def h():
@@ -1316,9 +1257,6 @@ def test_order_subclass():
 
 
 def test_registry_single_factory_argument():
-    class MyApp(App):
-        pass
-
     class Other(object):
         factory_arguments = {
             'my': list
@@ -1327,7 +1265,6 @@ def test_registry_single_factory_argument():
         def __init__(self, my):
             self.my = my
 
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list,
@@ -1343,6 +1280,9 @@ def test_registry_single_factory_argument():
         def perform(self, obj, my, other):
             my.append((self.message, obj))
 
+    class MyApp(App):
+        foo = directive(MyDirective)
+
     @MyApp.foo('hello')
     def f():
         pass
@@ -1353,9 +1293,6 @@ def test_registry_single_factory_argument():
 
 
 def test_registry_factory_argument_introduces_new_registry():
-    class MyApp(App):
-        pass
-
     class Other(object):
         factory_arguments = {
             'my': list
@@ -1364,7 +1301,6 @@ def test_registry_factory_argument_introduces_new_registry():
         def __init__(self, my):
             self.my = my
 
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'other': Other
@@ -1379,6 +1315,10 @@ def test_registry_factory_argument_introduces_new_registry():
         def perform(self, obj, other):
             other.my.append((self.message, obj))
 
+    class MyApp(App):
+        foo = directive(MyDirective)
+
+
     @MyApp.foo('hello')
     def f():
         pass
@@ -1390,12 +1330,6 @@ def test_registry_factory_argument_introduces_new_registry():
 
 
 def test_registry_factory_argument_introduces_new_registry_subclass():
-    class MyApp(App):
-        pass
-
-    class SubApp(MyApp):
-        pass
-
     class IsUsedElsewhere(object):
         poked = False
 
@@ -1407,7 +1341,6 @@ def test_registry_factory_argument_introduces_new_registry_subclass():
         def __init__(self, my):
             self.my = my
 
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'other': Other
@@ -1423,6 +1356,12 @@ def test_registry_factory_argument_introduces_new_registry_subclass():
             assert not other.my.poked
             other.my.poked = True
 
+    class MyApp(App):
+        foo = directive(MyDirective)
+
+    class SubApp(MyApp):
+        pass
+
     @MyApp.foo('hello')
     def f():
         pass
@@ -1436,9 +1375,6 @@ def test_registry_factory_argument_introduces_new_registry_subclass():
 
 
 def test_registry_multiple_factory_arguments():
-    class MyApp(App):
-        pass
-
     class Other(object):
         factory_arguments = {
             'my': list,
@@ -1449,7 +1385,6 @@ def test_registry_multiple_factory_arguments():
             self.my = my
             self.my2 = my2
 
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list,
@@ -1467,6 +1402,9 @@ def test_registry_multiple_factory_arguments():
             my.append((self.message, obj))
             my2.append('blah')
 
+    class MyApp(App):
+        foo = directive(MyDirective)
+
     @MyApp.foo('hello')
     def f():
         pass
@@ -1478,9 +1416,6 @@ def test_registry_multiple_factory_arguments():
 
 
 def test_registry_factory_arguments_depends():
-    class MyApp(App):
-        pass
-
     class Other(object):
         factory_arguments = {
             'my': list
@@ -1489,7 +1424,6 @@ def test_registry_factory_arguments_depends():
         def __init__(self, my):
             self.my = my
 
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'my': list
@@ -1504,7 +1438,6 @@ def test_registry_factory_arguments_depends():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         config = {
             'other': Other
@@ -1521,6 +1454,10 @@ def test_registry_factory_arguments_depends():
         def perform(self, obj, other):
             pass
 
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
+
     @MyApp.foo('hello')
     def f():
         pass
@@ -1531,9 +1468,6 @@ def test_registry_factory_arguments_depends():
 
 
 def test_registry_factory_arguments_depends_complex():
-    class MyApp(App):
-        pass
-
     class Registry(object):
         pass
 
@@ -1545,21 +1479,23 @@ def test_registry_factory_arguments_depends_complex():
         def __init__(self, registry):
             self.registry = registry
 
-    @MyApp.directive('setting')
     class SettingAction(Action):
         config = {'registry': Registry}
 
-    @MyApp.directive('predicate')
     class PredicateAction(Action):
         config = {'predicate_registry': PredicateRegistry}
 
         depends = [SettingAction]
 
-    @MyApp.directive('view')
     class ViewAction(Action):
         config = {'registry': Registry}
 
         depends = [PredicateAction]
+
+    class MyApp(App):
+        setting = directive(SettingAction)
+        predicate = directive(PredicateAction)
+        view = directive(ViewAction)
 
     commit(MyApp)
 
@@ -1578,11 +1514,7 @@ def test_is_committed():
 
 
 def test_registry_config_inconsistent():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
-    class MyDirective(Action):
+    class FooDirective(Action):
         config = {
             'my': list
         }
@@ -1596,8 +1528,7 @@ def test_registry_config_inconsistent():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.directive('bar')
-    class MyDirective(Action):  # flake8: noqa
+    class BarDirective(Action):
         config = {
             'my': dict
         }
@@ -1611,14 +1542,15 @@ def test_registry_config_inconsistent():
         def perform(self, obj, my):
             my[self.message] = obj
 
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
+
     with pytest.raises(ConfigError):
         commit(MyApp)
 
 
 def test_registry_factory_argument_inconsistent():
-    class MyApp(App):
-        pass
-
     class Other(object):
         factory_arguments = {
             'my': list
@@ -1635,7 +1567,6 @@ def test_registry_factory_argument_inconsistent():
         def __init__(self, my):
             self.my = my
 
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'other': Other,
@@ -1651,14 +1582,14 @@ def test_registry_factory_argument_inconsistent():
         def perform(self, obj, other, yetanother):
             pass
 
+    class MyApp(App):
+        foo = directive(MyDirective)
+
     with pytest.raises(ConfigError):
         commit(MyApp)
 
 
 def test_registry_factory_argument_and_config_inconsistent():
-    class MyApp(App):
-        pass
-
     class Other(object):
         factory_arguments = {
             'my': dict
@@ -1667,7 +1598,6 @@ def test_registry_factory_argument_and_config_inconsistent():
         def __init__(self, my):
             self.my = my
 
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list,
@@ -1683,33 +1613,37 @@ def test_registry_factory_argument_and_config_inconsistent():
         def perform(self, obj, my, other):
             my.append((self.message, obj))
 
+    class MyApp(App):
+        foo = directive(MyDirective)
+
     with pytest.raises(ConfigError):
         commit(MyApp)
 
 
-# Due to PEP 3155, having this class defined at the module top-level ensures
-# that its repr is the same in both Python 2 and 3.
+# making this global to ensure the repr is the same
+# on Python 3.5 and earlier versions (see PEP 3155)
+class ReprDirective(Action):
+    """Doc"""
+    config = {
+        'my': list
+    }
+
+    def __init__(self, message):
+        self.message = message
+
+    def identifier(self, my):
+        return self.message
+
+    def perform(self, obj, my):
+        my.append((self.message, obj))
+
+
 class MyAppForRepr(App):
-    pass
+    foo = directive(ReprDirective)
 
 
 def test_directive_repr():
-
-    @MyAppForRepr.directive('foo')
-    class MyDirective(Action):
-        """Doc"""
-        config = {
-            'my': list
-        }
-
-        def __init__(self, message):
-            self.message = message
-
-        def identifier(self, my):
-            return self.message
-
-        def perform(self, obj, my):
-            my.append((self.message, obj))
+    MyAppForRepr.commit()
 
     assert repr(MyAppForRepr.foo) == (
         "<bound method AppMeta.foo of "
@@ -1717,13 +1651,6 @@ def test_directive_repr():
 
 
 def test_app_class_passed_into_action():
-    class MyApp(App):
-        touched = []
-
-    class SubApp(MyApp):
-        touched = []
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -1740,6 +1667,14 @@ def test_app_class_passed_into_action():
         def perform(self, obj, app_class, my):
             app_class.touched.append(None)
             my.append((self.message, obj))
+
+    class MyApp(App):
+        touched = []
+
+        foo = directive(MyDirective)
+
+    class SubApp(MyApp):
+        touched = []
 
     @MyApp.foo('hello')
     def f():
@@ -1759,11 +1694,7 @@ def test_app_class_passed_into_action():
     assert SubApp.touched == [None]
 
 
-
 def test_app_class_passed_into_factory():
-    class MyApp(App):
-        touched = False
-
     class Other(object):
         factory_arguments = {
             'my': list
@@ -1778,7 +1709,6 @@ def test_app_class_passed_into_factory():
         def touch(self):
             self.app_class.touched = True
 
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'other': Other
@@ -1792,6 +1722,11 @@ def test_app_class_passed_into_factory():
 
         def perform(self, obj, other):
             other.touch()
+
+    class MyApp(App):
+        touched = False
+
+        foo = directive(MyDirective)
 
     @MyApp.foo()
     def f():
@@ -1805,9 +1740,6 @@ def test_app_class_passed_into_factory():
 
 
 def test_app_class_passed_into_factory_no_factory_arguments():
-    class MyApp(App):
-        touched = False
-
     class Other(object):
         app_class_arg = True
 
@@ -1817,7 +1749,6 @@ def test_app_class_passed_into_factory_no_factory_arguments():
         def touch(self):
             self.app_class.touched = True
 
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'other': Other
@@ -1832,6 +1763,11 @@ def test_app_class_passed_into_factory_no_factory_arguments():
         def perform(self, obj, other):
             other.touch()
 
+    class MyApp(App):
+        touched = False
+
+        foo = directive(MyDirective)
+
     @MyApp.foo()
     def f():
         pass
@@ -1844,12 +1780,6 @@ def test_app_class_passed_into_factory_no_factory_arguments():
 
 
 def test_app_class_passed_into_factory_separation():
-    class MyApp(App):
-        touched = False
-
-    class SubApp(MyApp):
-        touched = False
-
     class Other(object):
         factory_arguments = {
             'my': list
@@ -1864,7 +1794,6 @@ def test_app_class_passed_into_factory_separation():
         def touch(self):
             self.app_class.touched = True
 
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'other': Other
@@ -1878,6 +1807,13 @@ def test_app_class_passed_into_factory_separation():
 
         def perform(self, obj, other):
             other.touch()
+
+    class MyApp(App):
+        touched = False
+        foo = directive(MyDirective)
+
+    class SubApp(MyApp):
+        touched = False
 
     @MyApp.foo()
     def f():
@@ -1896,16 +1832,7 @@ def test_app_class_passed_into_factory_separation():
     assert SubApp.touched
 
 
-
 def test_app_class_cleanup():
-    class MyApp(App):
-        touched = []
-
-        @classmethod
-        def clean(cls):
-            cls.touched = []
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
         }
@@ -1920,6 +1847,15 @@ def test_app_class_cleanup():
 
         def perform(self, obj, app_class):
             app_class.touched.append(None)
+
+    class MyApp(App):
+        touched = []
+
+        @classmethod
+        def clean(cls):
+            cls.touched = []
+
+        foo = directive(MyDirective)
 
     @MyApp.foo()
     def f():

--- a/dectate/tests/test_directive.py
+++ b/dectate/tests/test_directive.py
@@ -32,6 +32,33 @@ def test_simple():
     assert MyApp.config.my == [('hello', f)]
 
 
+def test_decorator():
+
+    class MyApp(App):
+        @directive
+        class foo(Action):
+            config = {
+                'my': list
+            }
+
+            def __init__(self, message):
+                self.message = message
+
+            def identifier(self, my):
+                return self.message
+
+            def perform(self, obj, my):
+                my.append((self.message, obj))
+
+    @MyApp.foo('hello')
+    def f():
+        pass
+
+    commit(MyApp)
+
+    assert MyApp.config.my == [('hello', f)]
+
+
 def test_commit_method():
     class MyDirective(Action):
         config = {

--- a/dectate/tests/test_directive.py
+++ b/dectate/tests/test_directive.py
@@ -1318,7 +1318,6 @@ def test_registry_factory_argument_introduces_new_registry():
     class MyApp(App):
         foo = directive(MyDirective)
 
-
     @MyApp.foo('hello')
     def f():
         pass

--- a/dectate/tests/test_directive.py
+++ b/dectate/tests/test_directive.py
@@ -1,4 +1,4 @@
-from dectate.app import App
+from dectate.app import App, directive
 from dectate.config import commit, Action, Composite
 from dectate.error import ConflictError, ConfigError
 
@@ -23,6 +23,33 @@ def test_simple():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    @MyApp.foo('hello')
+    def f():
+        pass
+
+    commit(MyApp)
+
+    assert MyApp.config.my == [('hello', f)]
+
+
+def test_simple_direct():
+    class MyDirective(Action):
+        config = {
+            'my': list
+        }
+
+        def __init__(self, message):
+            self.message = message
+
+        def identifier(self, my):
+            return self.message
+
+        def perform(self, obj, my):
+            my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
 
     @MyApp.foo('hello')
     def f():

--- a/dectate/tests/test_error.py
+++ b/dectate/tests/test_error.py
@@ -1,4 +1,4 @@
-from dectate.app import App
+from dectate.app import App, directive
 from dectate.config import commit, Action, Composite
 
 from dectate.error import (ConflictError, ConfigError, DirectiveError,
@@ -9,10 +9,6 @@ import pytest
 
 
 def test_directive_error_in_action():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         def __init__(self, name):
             self.name = name
@@ -22,6 +18,9 @@ def test_directive_error_in_action():
 
         def perform(self, obj):
             raise DirectiveError("A real problem")
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     @MyApp.foo('hello')
     def f():
@@ -37,16 +36,15 @@ def test_directive_error_in_action():
 
 
 def test_directive_error_in_composite():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Composite):
         def __init__(self, name):
             self.name = name
 
         def actions(self, obj):
             raise DirectiveError("Something went wrong")
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     @MyApp.foo('hello')
     def f():
@@ -62,10 +60,6 @@ def test_directive_error_in_composite():
 
 
 def test_conflict_error():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         def __init__(self, name):
             self.name = name
@@ -75,6 +69,9 @@ def test_conflict_error():
 
         def perform(self, obj):
             raise DirectiveError("A real problem")
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     @MyApp.foo('hello')
     def f():
@@ -95,10 +92,6 @@ def test_conflict_error():
 
 
 def test_with_statement_error():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         def __init__(self, model, name):
             self.model = model
@@ -109,6 +102,9 @@ def test_with_statement_error():
 
         def perform(self, obj):
             raise DirectiveError("A real problem")
+
+    class MyApp(App):
+        foo = directive(FooDirective)
 
     class Dummy(object):
         pass
@@ -133,10 +129,6 @@ def test_with_statement_error():
 
 
 def test_composite_codeinfo_propagation():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('sub')
     class SubDirective(Action):
         config = {
             'my': list
@@ -151,13 +143,16 @@ def test_composite_codeinfo_propagation():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.directive('composite')
     class CompositeDirective(Composite):
         def __init__(self, messages):
             self.messages = messages
 
         def actions(self, obj):
             return [(SubDirective(message), obj) for message in self.messages]
+
+    class MyApp(App):
+        _sub = directive(SubDirective)
+        composite = directive(CompositeDirective)
 
     @MyApp.composite(['a'])
     def f():
@@ -177,10 +172,6 @@ def test_composite_codeinfo_propagation():
 
 
 def test_type_error_not_enough_arguments():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -194,6 +185,9 @@ def test_type_error_not_enough_arguments():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
 
     # not enough arguments
     @MyApp.foo()
@@ -208,10 +202,6 @@ def test_type_error_not_enough_arguments():
 
 
 def test_type_error_too_many_arguments():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -226,6 +216,9 @@ def test_type_error_too_many_arguments():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
+    class MyApp(App):
+        foo = directive(MyDirective)
+
     # not enough arguments
     @MyApp.foo('a', 'b')
     def f():
@@ -239,10 +232,6 @@ def test_type_error_too_many_arguments():
 
 
 def test_cannot_group_class_group_class():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'foo': list
@@ -257,29 +246,28 @@ def test_cannot_group_class_group_class():
         def perform(self, obj, foo):
             foo.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         group_class = FooDirective
 
         def __init__(self, message):
             pass
 
-    @MyApp.directive('qux')
     class QuxDirective(Action):
         group_class = BarDirective  # should go to FooDirective instead
 
         def __init__(self, message):
             pass
 
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
+        qux = directive(QuxDirective)
+
     with pytest.raises(ConfigError):
         commit(MyApp)
 
 
 def test_cannot_use_config_with_group_class():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'foo': list
@@ -294,7 +282,6 @@ def test_cannot_use_config_with_group_class():
         def perform(self, obj, foo):
             foo.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         config = {
             'bar': list
@@ -305,15 +292,15 @@ def test_cannot_use_config_with_group_class():
         def __init__(self, message):
             pass
 
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
+
     with pytest.raises(ConfigError):
         commit(MyApp)
 
 
 def test_cann_inherit_config_with_group_class():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'foo': list
@@ -328,21 +315,20 @@ def test_cann_inherit_config_with_group_class():
         def perform(self, obj, foo):
             foo.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(FooDirective):
         group_class = FooDirective
 
         def __init__(self, message):
             pass
 
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
+
     commit(MyApp)
 
 
 def test_cannot_use_before_with_group_class():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'foo': list
@@ -357,7 +343,6 @@ def test_cannot_use_before_with_group_class():
         def perform(self, obj, foo):
             foo.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         group_class = FooDirective
 
@@ -365,15 +350,15 @@ def test_cannot_use_before_with_group_class():
         def before():
             pass
 
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
+
     with pytest.raises(ConfigError):
         commit(MyApp)
 
 
 def test_can_inherit_before_with_group_class():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'foo': list
@@ -392,18 +377,17 @@ def test_can_inherit_before_with_group_class():
         def before(foo):
             pass
 
-    @MyApp.directive('bar')
     class BarDirective(FooDirective):
         group_class = FooDirective
+
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
 
     commit(MyApp)
 
 
 def test_cannot_use_after_with_group_class():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'foo': list
@@ -418,7 +402,6 @@ def test_cannot_use_after_with_group_class():
         def perform(self, obj, foo):
             foo.append((self.message, obj))
 
-    @MyApp.directive('bar')
     class BarDirective(Action):
         group_class = FooDirective
 
@@ -426,15 +409,15 @@ def test_cannot_use_after_with_group_class():
         def after():
             pass
 
+    class MyApp(App):
+        foo = directive(FooDirective)
+        bar = directive(BarDirective)
+
     with pytest.raises(ConfigError):
         commit(MyApp)
 
 
 def test_action_without_init():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooDirective(Action):
         config = {
             'foo': list
@@ -446,6 +429,9 @@ def test_action_without_init():
         def perform(self, obj, foo):
             foo.append(obj)
 
+    class MyApp(App):
+        foo = directive(FooDirective)
+
     @MyApp.foo()
     def f():
         pass
@@ -456,10 +442,6 @@ def test_action_without_init():
 
 
 def test_composite_without_init():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('sub')
     class SubDirective(Action):
         config = {
             'my': list
@@ -474,10 +456,13 @@ def test_composite_without_init():
         def perform(self, obj, my):
             my.append((self.message, obj))
 
-    @MyApp.directive('composite')
     class CompositeDirective(Composite):
         def actions(self, obj):
             return [(SubDirective(message), obj) for message in ['a', 'b']]
+
+    class MyApp(App):
+        _sub = directive(SubDirective)
+        composite = directive(CompositeDirective)
 
     commit(MyApp)
 

--- a/dectate/tests/test_error.py
+++ b/dectate/tests/test_error.py
@@ -219,7 +219,7 @@ def test_type_error_too_many_arguments():
     class MyApp(App):
         foo = directive(MyDirective)
 
-    # not enough arguments
+    # too many arguments
     @MyApp.foo('a', 'b')
     def f():
         pass

--- a/dectate/tests/test_logging.py
+++ b/dectate/tests/test_logging.py
@@ -1,5 +1,5 @@
 import logging
-from dectate.app import App
+from dectate.app import App, directive
 from dectate.config import Action, commit
 
 
@@ -35,10 +35,6 @@ def test_simple_config_logging():
     log.addHandler(test_handler)
     log.setLevel(logging.DEBUG)
 
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -52,6 +48,9 @@ def test_simple_config_logging():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
 
     @MyApp.foo('hello')
     def f():
@@ -76,10 +75,6 @@ def test_subclass_config_logging():
     log.addHandler(test_handler)
     log.setLevel(logging.DEBUG)
 
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -93,6 +88,9 @@ def test_subclass_config_logging():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        foo = directive(MyDirective)
 
     class SubApp(MyApp):
         pass
@@ -127,10 +125,6 @@ def test_override_logger_name():
     log.addHandler(test_handler)
     log.setLevel(logging.DEBUG)
 
-    class MyApp(App):
-        logger_name = 'morepath.directive'
-
-    @MyApp.directive('foo')
     class MyDirective(Action):
         config = {
             'my': list
@@ -144,6 +138,11 @@ def test_override_logger_name():
 
         def perform(self, obj, my):
             my.append((self.message, obj))
+
+    class MyApp(App):
+        logger_name = 'morepath.directive'
+
+        foo = directive(MyDirective)
 
     @MyApp.foo('hello')
     def f():

--- a/dectate/tests/test_query.py
+++ b/dectate/tests/test_query.py
@@ -1,14 +1,10 @@
 import pytest
 
 from dectate import (
-    Query, App, Action, Composite, commit, QueryError, NOT_FOUND)
+    Query, App, Action, Composite, directive, commit, QueryError, NOT_FOUND)
 
 
 def test_query():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -22,6 +18,9 @@ def test_query():
 
         def perform(self, obj, registry):
             registry.append((self.name, obj))
+
+    class MyApp(App):
+        foo = directive(FooAction)
 
     @MyApp.foo('a')
     def f():
@@ -42,10 +41,6 @@ def test_query():
 
 
 def test_query_directive_name():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -59,6 +54,9 @@ def test_query_directive_name():
 
         def perform(self, obj, registry):
             registry.append((self.name, obj))
+
+    class MyApp(App):
+        foo = directive(FooAction)
 
     @MyApp.foo('a')
     def f():
@@ -79,10 +77,6 @@ def test_query_directive_name():
 
 
 def test_multi_action_query():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -97,7 +91,6 @@ def test_multi_action_query():
         def perform(self, obj, registry):
             registry.append((self.name, obj))
 
-    @MyApp.directive('bar')
     class BarAction(Action):
         config = {
             'registry': list
@@ -111,6 +104,10 @@ def test_multi_action_query():
 
         def perform(self, obj, registry):
             registry.append((self.name, obj))
+
+    class MyApp(App):
+        foo = directive(FooAction)
+        bar = directive(BarAction)
 
     @MyApp.foo('a')
     def f():
@@ -131,10 +128,6 @@ def test_multi_action_query():
 
 
 def test_filter():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -148,6 +141,9 @@ def test_filter():
 
         def perform(self, obj, registry):
             registry.append((self.name, obj))
+
+    class MyApp(App):
+        foo = directive(FooAction)
 
     @MyApp.foo('a')
     def f():
@@ -167,10 +163,6 @@ def test_filter():
 
 
 def test_filter_multiple_fields():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -189,6 +181,9 @@ def test_filter_multiple_fields():
 
         def perform(self, obj, registry):
             registry.append((self.model, self.name, obj))
+
+    class MyApp(App):
+        foo = directive(FooAction)
 
     class Alpha(object):
         pass
@@ -223,10 +218,6 @@ def test_filter_multiple_fields():
 
 
 def test_filter_not_found():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -240,6 +231,9 @@ def test_filter_not_found():
 
         def perform(self, obj, registry):
             registry.append((self.name, obj))
+
+    class MyApp(App):
+        foo = directive(FooAction)
 
     @MyApp.foo('a')
     def f():
@@ -257,10 +251,6 @@ def test_filter_not_found():
 
 
 def test_filter_different_attribute_name():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -279,6 +269,9 @@ def test_filter_different_attribute_name():
         def perform(self, obj, registry):
             registry.append((self._name, obj))
 
+    class MyApp(App):
+        foo = directive(FooAction)
+
     @MyApp.foo('a')
     def f():
         pass
@@ -295,10 +288,6 @@ def test_filter_different_attribute_name():
 
 
 def test_filter_get_value():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         def filter_get_value(self, name):
             return self.kw.get(name, NOT_FOUND)
@@ -311,6 +300,9 @@ def test_filter_get_value():
 
         def perform(self, obj):
             pass
+
+    class MyApp(App):
+        foo = directive(FooAction)
 
     @MyApp.foo(x='a', y='b')
     def f():
@@ -333,10 +325,6 @@ def test_filter_get_value():
 
 
 def test_filter_name_and_get_value():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         filter_name = {
             'name': '_name'
@@ -355,6 +343,9 @@ def test_filter_name_and_get_value():
         def perform(self, obj):
             pass
 
+    class MyApp(App):
+        foo = directive(FooAction)
+
     @MyApp.foo(name='hello', x='a', y='b')
     def f():
         pass
@@ -371,10 +362,6 @@ def test_filter_name_and_get_value():
 
 
 def test_filter_get_value_and_default():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         def filter_get_value(self, name):
             return self.kw.get(name, NOT_FOUND)
@@ -388,6 +375,9 @@ def test_filter_get_value_and_default():
 
         def perform(self, obj):
             pass
+
+    class MyApp(App):
+        foo = directive(FooAction)
 
     @MyApp.foo(name='hello', x='a', y='b')
     def f():
@@ -405,10 +395,6 @@ def test_filter_get_value_and_default():
 
 
 def test_filter_class():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('view')
     class ViewAction(Action):
         config = {
             'registry': list
@@ -426,6 +412,9 @@ def test_filter_class():
 
         def perform(self, obj, registry):
             registry.append((self.model, obj))
+
+    class MyApp(App):
+        view = directive(ViewAction)
 
     class Alpha(object):
         pass
@@ -467,10 +456,6 @@ def test_filter_class():
 
 
 def test_query_group_class():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -485,9 +470,12 @@ def test_query_group_class():
         def perform(self, obj, registry):
             registry.append((self.name, obj))
 
-    @MyApp.directive('bar')
     class BarAction(FooAction):
         group_class = FooAction
+
+    class MyApp(App):
+        foo = directive(FooAction)
+        bar = directive(BarAction)
 
     @MyApp.foo('a')
     def f():
@@ -508,10 +496,6 @@ def test_query_group_class():
 
 
 def test_query_on_group_class_action():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -526,9 +510,12 @@ def test_query_on_group_class_action():
         def perform(self, obj, registry):
             registry.append((self.name, obj))
 
-    @MyApp.directive('bar')
     class BarAction(FooAction):
         group_class = FooAction
+
+    class MyApp(App):
+        foo = directive(FooAction)
+        bar = directive(BarAction)
 
     @MyApp.foo('a')
     def f():
@@ -549,10 +536,6 @@ def test_query_on_group_class_action():
 
 
 def test_multi_query_on_group_class_action():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -567,9 +550,12 @@ def test_multi_query_on_group_class_action():
         def perform(self, obj, registry):
             registry.append((self.name, obj))
 
-    @MyApp.directive('bar')
     class BarAction(FooAction):
         group_class = FooAction
+
+    class MyApp(App):
+        foo = directive(FooAction)
+        bar = directive(BarAction)
 
     @MyApp.foo('a')
     def f():
@@ -590,13 +576,6 @@ def test_multi_query_on_group_class_action():
 
 
 def test_inheritance():
-    class MyApp(App):
-        pass
-
-    class SubApp(MyApp):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -610,6 +589,12 @@ def test_inheritance():
 
         def perform(self, obj, registry):
             registry.append((self.name, obj))
+
+    class MyApp(App):
+        foo = directive(FooAction)
+
+    class SubApp(MyApp):
+        pass
 
     @MyApp.foo('a')
     def f():
@@ -630,10 +615,6 @@ def test_inheritance():
 
 
 def test_composite_action():
-    class MyApp(App):
-        pass
-
-    @MyApp.private_action_class
     class SubAction(Action):
         config = {
             'registry': list
@@ -648,7 +629,6 @@ def test_composite_action():
         def perform(self, obj, registry):
             registry.append((self.name, obj))
 
-    @MyApp.directive('composite')
     class CompositeAction(Composite):
         query_classes = [
             SubAction
@@ -659,6 +639,10 @@ def test_composite_action():
 
         def actions(self, obj):
             return [(SubAction(name), obj) for name in self.names]
+
+    class MyApp(App):
+        _sub = directive(SubAction)
+        composite = directive(CompositeAction)
 
     @MyApp.composite(['a', 'b'])
     def f():
@@ -675,10 +659,6 @@ def test_composite_action():
 
 
 def test_composite_action_without_query_classes():
-    class MyApp(App):
-        pass
-
-    @MyApp.private_action_class
     class SubAction(Action):
         config = {
             'registry': list
@@ -693,13 +673,16 @@ def test_composite_action_without_query_classes():
         def perform(self, obj, registry):
             registry.append((self.name, obj))
 
-    @MyApp.directive('composite')
     class CompositeAction(Composite):
         def __init__(self, names):
             self.names = names
 
         def actions(self, obj):
             return [(SubAction(name), obj) for name in self.names]
+
+    class MyApp(App):
+        _sub = directive(SubAction)
+        composite = directive(CompositeAction)
 
     @MyApp.composite(['a', 'b'])
     def f():
@@ -714,10 +697,6 @@ def test_composite_action_without_query_classes():
 
 
 def test_nested_composite_action():
-    class MyApp(App):
-        pass
-
-    @MyApp.private_action_class
     class SubSubAction(Action):
         config = {
             'registry': list
@@ -732,7 +711,6 @@ def test_nested_composite_action():
         def perform(self, obj, registry):
             registry.append((self.name, obj))
 
-    @MyApp.private_action_class
     class SubAction(Composite):
         query_classes = [
             SubSubAction
@@ -744,7 +722,6 @@ def test_nested_composite_action():
         def actions(self, obj):
             return [(SubSubAction(name), obj) for name in self.names]
 
-    @MyApp.directive('composite')
     class CompositeAction(Composite):
         query_classes = [
             SubAction
@@ -756,6 +733,11 @@ def test_nested_composite_action():
         def actions(self, obj):
             for i in range(self.amount):
                 yield SubAction(['a%s' % i, 'b%s' % i]), obj
+
+    class MyApp(App):
+        _subsub = directive(SubSubAction)
+        _sub = directive(SubAction)
+        composite = directive(CompositeAction)
 
     @MyApp.composite(2)
     def f():
@@ -774,13 +756,6 @@ def test_nested_composite_action():
 
 
 def test_query_action_for_other_app():
-    class MyApp(App):
-        pass
-
-    class OtherApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         config = {
             'registry': list
@@ -795,7 +770,6 @@ def test_query_action_for_other_app():
         def perform(self, obj, registry):
             registry.append((self.name, obj))
 
-    @OtherApp.directive('foo')
     class BarAction(Action):
         config = {
             'registry': list
@@ -809,6 +783,12 @@ def test_query_action_for_other_app():
 
         def perform(self, obj, registry):
             registry.append((self.name, obj))
+
+    class MyApp(App):
+        foo = directive(FooAction)
+
+    class OtherApp(App):
+        bar = directive(BarAction)
 
     @MyApp.foo('a')
     def f():

--- a/dectate/tests/test_tool.py
+++ b/dectate/tests/test_tool.py
@@ -2,7 +2,7 @@ import pytest
 from argparse import ArgumentTypeError
 
 from dectate.config import Action, commit
-from dectate.app import App
+from dectate.app import App, directive
 from dectate.tool import (parse_app_class, parse_directive, parse_filters,
                           convert_filters,
                           convert_dotted_name, convert_bool,
@@ -122,10 +122,6 @@ def test_convert_filters_value_error():
 
 
 def test_query_tool_output():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         def __init__(self, name):
             self.name = name
@@ -135,6 +131,9 @@ def test_query_tool_output():
 
         def perform(self, obj):
             pass
+
+    class MyApp(App):
+        foo = directive(FooAction)
 
     @MyApp.foo('a')
     def f():
@@ -155,19 +154,6 @@ def test_query_tool_output():
 
 
 def test_query_tool_output_multiple_apps():
-    class Base(App):
-        pass
-
-    class AlphaApp(Base):
-        pass
-
-    class BetaApp(Base):
-        pass
-
-    class GammaApp(Base):
-        pass
-
-    @Base.directive('foo')
     class FooAction(Action):
         def __init__(self, name):
             self.name = name
@@ -177,6 +163,18 @@ def test_query_tool_output_multiple_apps():
 
         def perform(self, obj):
             pass
+
+    class Base(App):
+        foo = directive(FooAction)
+
+    class AlphaApp(Base):
+        pass
+
+    class BetaApp(Base):
+        pass
+
+    class GammaApp(Base):
+        pass
 
     @AlphaApp.foo('a')
     def f():
@@ -194,10 +192,6 @@ def test_query_tool_output_multiple_apps():
 
 
 def test_query_app():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         filter_convert = {
             'count': int
@@ -211,6 +205,9 @@ def test_query_app():
 
         def perform(self, obj):
             pass
+
+    class MyApp(App):
+        foo = directive(FooAction)
 
     @MyApp.foo(1)
     def f():
@@ -228,10 +225,6 @@ def test_query_app():
 
 
 def test_query_tool_uncommitted():
-    class MyApp(App):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         def __init__(self, name):
             self.name = name
@@ -241,6 +234,9 @@ def test_query_tool_uncommitted():
 
         def perform(self, obj):
             pass
+
+    class MyApp(App):
+        foo = directive(FooAction)
 
     @MyApp.foo('a')
     def f():
@@ -277,13 +273,6 @@ def test_app_without_directive():
 
 
 def test_inheritance():
-    class MyApp(App):
-        pass
-
-    class SubApp(MyApp):
-        pass
-
-    @MyApp.directive('foo')
     class FooAction(Action):
         filter_convert = {
             'count': int
@@ -297,6 +286,12 @@ def test_inheritance():
 
         def perform(self, obj):
             pass
+
+    class MyApp(App):
+        foo = directive(FooAction)
+
+    class SubApp(MyApp):
+        pass
 
     @MyApp.foo(1)
     def f():

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -20,6 +20,8 @@ API
   :inherited-members:
   :members:
 
+.. autofunction:: directive
+
 .. autofunction:: query_tool
 
 .. autofunction:: query_app


### PR DESCRIPTION
This removes the `directive` directive and replaces it with a `dectate.directive` function that can be used to install action classes as directives into app classes. This fixes #37 
