### PR TITLE
Maintenance work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ dist: xenial
 language: python
 
 python:
-    - "3.4"
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"
-    - "pypy3.6-7.1.1"
+    - "pypy3"
 matrix:
     include:
     - python: "3.7"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,11 @@ CHANGES
 0.15 (unreleased)
 =================
 
-- Nothing changed yet.
+- Fix Flake8 errors.
+
+- Apply Black code formatter.
+
+- Drop support for Python 3.4 and 3.5.
 
 
 0.14 (2020-01-29)

--- a/dectate/config.py
+++ b/dectate/config.py
@@ -35,13 +35,13 @@ class Configurable(object):
 
     def __init__(self, extends, config):
         """
-       :param extends:
-          the configurables that this configurable extends.
-        :type extends: list of configurables.
-        :param config:
-          the object that will contains the actual configuration.
-          Normally it's the ``config`` class attribute of the
-          :class:`dectate.App` subclass.
+        :param extends:
+           the configurables that this configurable extends.
+         :type extends: list of configurables.
+         :param config:
+           the object that will contains the actual configuration.
+           Normally it's the ``config`` class attribute of the
+           :class:`dectate.App` subclass.
         """
         self.extends = extends
         self.config = config
@@ -65,8 +65,7 @@ class Configurable(object):
         self._directives.append((directive, obj))
 
     def _fixup_directive_names(self):
-        """Set up correct name for directives.
-        """
+        """Set up correct name for directives."""
         app_class = self.app_class
         for name, method in app_class.get_directive_methods():
             func = method.__func__
@@ -172,8 +171,7 @@ class Configurable(object):
                     delattr(config, name)
 
     def group_actions(self):
-        """Groups actions for this configurable into action groups.
-        """
+        """Groups actions for this configurable into action groups."""
         # turn directives into actions
         actions = [
             (directive.action(), obj) for (directive, obj) in self._directives
@@ -211,8 +209,7 @@ class Configurable(object):
         ]
 
     def execute(self):
-        """Execute actions for configurable.
-        """
+        """Execute actions for configurable."""
         self.app_class.clean()
         self.setup()
         self.group_actions()
@@ -479,8 +476,7 @@ class Action(metaclass=abc.ABCMeta):
         return self.directive.code_info
 
     def _log(self, configurable, obj):
-        """Log this directive for configurable given configured obj.
-        """
+        """Log this directive for configurable given configured obj."""
         if self.directive is None:
             return
         self.directive.log(configurable, obj)
@@ -780,15 +776,13 @@ class Directive(object):
 
 
 class DirectiveAbbreviation(object):
-    """An abbreviated directive to be used with the ``with`` statement.
-    """
+    """An abbreviated directive to be used with the ``with`` statement."""
 
     def __init__(self, directive):
         self.directive = directive
 
     def __call__(self, *args, **kw):
-        """Combine the args and kw from the directive with supplied ones.
-        """
+        """Combine the args and kw from the directive with supplied ones."""
         frame = sys._getframe(1)
         code_info = create_code_info(frame)
         directive = self.directive

--- a/dectate/error.py
+++ b/dectate/error.py
@@ -2,8 +2,7 @@
 
 
 class ConfigError(Exception):
-    """Raised when configuration is bad.
-    """
+    """Raised when configuration is bad."""
 
 
 def conflict_keyfunc(action):

--- a/dectate/tool.py
+++ b/dectate/tool.py
@@ -180,8 +180,7 @@ def convert_filters(action_class, filters):
 
 
 def resolve_dotted_name(name, module=None):
-    """Adapted from zope.dottedname
-    """
+    """Adapted from zope.dottedname"""
     name = name.split(".")
     if not name[0]:
         if module is None:

--- a/dectate/toposort.py
+++ b/dectate/toposort.py
@@ -1,7 +1,7 @@
 from .error import TopologicalSortError
 
 
-def topological_sort(l, get_depends):
+def topological_sort(l, get_depends):  # noqa: E741
     """`Topological sort`_
 
     .. _`Topological sort`: https://en.wikipedia.org/wiki/Topological_sorting

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Topic :: Software Development :: Libraries :: Application Frameworks",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, py37, py38, pypy3, coverage, pep8, docs
+envlist = py36, py37, py38, pypy3, coverage, pep8, docs
 skipsdist = True
 skip_missing_interpreters = True
 
@@ -7,20 +7,20 @@ skip_missing_interpreters = True
 usedevelop = True
 extras = test
 
-commands = py.test {posargs}
+commands = pytest {posargs}
 
 [testenv:coverage]
 basepython = python3.7
 extras = test
          coverage
 
-commands = py.test --cov {posargs}
+commands = pytest --cov {posargs}
 
 [testenv:pep8]
 basepython = python3.7
 extras = pep8
 
-commands = flake8 dectate *.py
+commands = flake8 dectate
            black --check .
 
 [testenv:docs]


### PR DESCRIPTION
- drop support for Python 3.4 and 3.5
- apply Black code formatter
- fix Flake8 erros
- Ignore flake8 warning for using name `l` as `topological_sort` is part of the public API.

fixes #46 